### PR TITLE
Fix for Errors like error LNK2005: _amx_* already defined in *.obj

### DIFF
--- a/NativeFunc.hpp
+++ b/NativeFunc.hpp
@@ -115,8 +115,8 @@ private:
 	cell*
 		params_;
 
-	static std::list<NativeFuncBase*>*
-		all_;
+	static inline std::list<NativeFuncBase*>*
+		all_ = nullptr;
 };
 
 template <typename RET, typename... TS>

--- a/NativesMain.hpp
+++ b/NativesMain.hpp
@@ -5,12 +5,9 @@
 namespace pawn_natives
 {
 #ifdef PAWN_NATIVES_HAS_FUNC
-std::list<NativeFuncBase*>*
-	NativeFuncBase::all_
-	= 0;
 #endif
 
-int AmxLoad(AMX* amx)
+inline int AmxLoad(AMX* amx)
 {
 	int
 		ret

--- a/NativesMain.hpp
+++ b/NativesMain.hpp
@@ -4,8 +4,6 @@
 
 namespace pawn_natives
 {
-#ifdef PAWN_NATIVES_HAS_FUNC
-#endif
 
 inline int AmxLoad(AMX* amx)
 {


### PR DESCRIPTION
related to : https://github.com/openmultiplayer/open.mp-sdk/pull/67
fixes for errors such as 
```
natives.obj : error LNK2005: "int __cdecl amx_GetNativeByIndex(struct tagAMX const *,int,struct tagAMX_NATIVE_INFO *)" (?amx_GetNati
veByIndex@@YAHPBUtagAMX@@HPAUtagAMX_NATIVE_INFO@@@Z) already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: "int __cdecl amx_MakeAddr(struct tagAMX *,__int64 *,__int64 *)" (?amx_MakeAddr@@YAHPAUtagAMX@@PA_J1@Z)
already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: "int __cdecl amx_StrSize(__int64 const *,int *)" (?amx_StrSize@@YAHPB_JPAH@Z) already defined in main.o
bj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Callback already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Cleanup already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Clone already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Exec already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindNative already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindPubVar already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindPublic already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_FindTagId already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Flags already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetAddr already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetNative already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetPubVar already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetPublic already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetString already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetTag already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_GetUserData already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Init already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_InitJIT already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_MemInfo already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NameLength already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NativeInfo already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumNatives already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumPubVars already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumPublics already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_NumTags already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Push already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_PushArray already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_PushString already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_PushStringLen already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_RaiseError already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Register already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Release already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetCallback already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetDebugHook already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetString already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetStringLen already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_SetUserData already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_StrLen already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_Swap64 already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Check already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Get already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Len already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
natives.obj : error LNK2005: _amx_UTF8Put already defined in main.obj [M:\MyJob\open.mp-time\build\omp-time.vcxproj]
     Creating library M:/MyJob/open.mp-time/build/RelWithDebInfo/omp-time.lib and object M:/MyJob/open.mp-time/build/RelWithDebInfo/
  omp-time.exp
M:\MyJob\open.mp-time\build\RelWithDebInfo\omp-time.dll : fatal error LNK1169: one or more multiply defined symbols found [M:\MyJob\
open.mp-time\build\omp-time.vcxproj]
```